### PR TITLE
Example for header/2

### DIFF
--- a/src/demos/demos_contenttype.erl
+++ b/src/demos/demos_contenttype.erl
@@ -2,7 +2,14 @@
 -include_lib ("nitrogen_core/include/wf.hrl").
 -compile(export_all).
 
-main() -> #template { file="./templates/demos46.html" }.
+main() -> 
+	case wf:q(postD) of 
+   		undefined ->
+   			#template { file="./templates/demos46.html" };
+   		_ ->
+   		   wf:header("Content-Disposition", "attachement; filename=\"nitrogen.jpeg\""),
+   		   demos_contenttype_image:main()
+   	end.
 
 title() -> "Content Type".
 
@@ -26,7 +33,13 @@ left() ->
 
 right() -> 
     [
-        #image { image="/demos/contenttype/image" }
+        #image { image="/demos/contenttype/image" },
+        [#restful_form{ 
+                                          action = "/demos_contenttype",
+                                          target = new,
+                                          body = [#hidden{id=postD, text = "Post"},
+                                                  #restful_submit{text = "Response Header Example"}]
+                                         }
     ].
 	
 event(_) -> ok.


### PR DESCRIPTION
This is an example for demonstrating hearder/2, I will rewrite as different module, not try and push it all into one module.

  For myself I do this a few times in practice so as well as demonstrating header/2, I thought would demonstrate the power of nitrogen, for example with the use of posts, then providing different content.

  I didn't actually try compiling this but sure it should be fine.
