### PR TITLE
Remove the need to have ssh keys installed on github

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -12,7 +12,7 @@ to see an example of how you can embed Nitrogen inside other applications.
 To get started, simply run:
 
 ```bash
-    git clone git://github.com/nitrogen/NitrogenProject.com.git
+    git clone https://github.com/nitrogen/NitrogenProject.com.git
 
     cd NitrogenProject.com
     make

--- a/src/downloads.erl
+++ b/src/downloads.erl
@@ -240,7 +240,7 @@ platform_downloads("git") ->
             #image { image="/images/git.png", style="width:80px" }
         ]},
         #span {class=title, text="Clone with Git"},
-        <<"<pre style='margin-top:0.5em; color: #333'>git clone git://github.com/nitrogen/nitrogen.git</pre>">>
+        <<"<pre style='margin-top:0.5em; color: #333'>git clone https://github.com/nitrogen/nitrogen.git</pre>">>
     ]};
 
 platform_downloads("source") ->


### PR DESCRIPTION
Hi, 

I think this is just a lot easier. 


Noticed that you specify git pulls that assume you have ssh keys installed.; as not everyone has ssh keys installed and/also you don't want to install every machine's ssh keys when pulling a repo this should be a simpler solution.