### PR TITLE
Adding rest handler demo

### DIFF
--- a/src/demos.erl
+++ b/src/demos.erl
@@ -58,6 +58,7 @@ middle() ->
         #link { text="Wizard", url="/demos/wizard" },#br{},
         #link { text="RESTful Forms", url="/demos/restful" }, #br{},
         #link { text="HTML and Custom Encoding", url="/demos/htmlencode"},#br{},
+        #link { text="Rest API handler", url="/demos/rest"}, #br{},
 %        #link { text="Recaptcha", url="/demos/recaptcha"},#br{},
 
         #h2 { text="Drag, Drop & Sort" },

--- a/src/demos/demos_rest.erl
+++ b/src/demos/demos_rest.erl
@@ -1,0 +1,50 @@
+-module (demos_rest).
+-include_lib ("nitrogen_core/include/wf.hrl").
+-compile(export_all).
+
+main() -> #template { file="./templates/demos46.html" }.
+	
+title() -> "Rest handler example".
+
+headline() -> "HTTP REST Handler".
+
+left() -> 
+    [
+        "
+        <p>
+        Nitrogen allows the creation of HTTP REST API endpoints.
+
+        <p> 
+        It is possible to use various HTTP methods to request and recieves responses through Nitrogen. Methods are provided for decoding & encoding json. Though you can use which ever JSON client you prefair.
+
+        <p>
+        You can use curl or any your favorite HHTP client such as postman..
+        "
+       , 
+       linecount:render()
+    ].
+
+right() -> 
+    [
+        "
+        <p>
+        You can test this using the path /demos/rest/api via these methods:
+        
+        <p>
+        <h3> GET </h3><br>
+        
+        curl -X GET \"http://nitrogenproject.com/demos/rest/api/name=m3rl1n&city=london\"
+
+        <p>
+        <h3> POST </h3><br>
+
+        curl -X POST \"http://nitrogenproject.com/demos/rest/api\" -d '{\"name\": \"th31nitiate\", \"city\": \"London\"}'
+
+        <p>
+        You can send similar posts request using your favorite HTTP clients such as Postman. 
+        "
+    ].
+
+event(_) -> ok.
+
+

--- a/src/demos/demos_rest_api.erl
+++ b/src/demos/demos_rest_api.erl
@@ -1,0 +1,24 @@
+%% -*- mode: nitrogen -*-
+-module (demos_rest_api).
+-compile(export_all).
+-include_lib("nitrogen_core/include/wf.hrl").
+-behavior(nitrogen_rest).
+ 
+get("") -> 
+    Resp = io_lib:format("A GET request has been submitted with the parameters: ~p~n", [wf:params()]),
+    {200, Resp}.
+
+post("") ->
+    %% The best way to post data is via the request body funcation
+    Params = wf:request_body(),
+    JsonPayload = wf:json_decode(Params),
+    Body = io_lib:format("A POST request has been submitted with the parameters: ~p~n", [JsonPayload]),
+    {200, Body}.
+
+put("") ->
+    Body = io_lib:format("A PUT request has been submitted with the parameters: ~p~n", ["N/A"]),
+    {200, Body}.
+
+delete("") ->
+    Body = io_lib:format("A DELETE request has been submitted with the parameters: ~p~n", ["N/A"]),
+    {200, Body}.


### PR DESCRIPTION
This should add a simple demo of the rest handler. It bear bones as I understand we do not have any specific convention here. Though feel free to let me know if there is anyway I can amend it.

I could of added something like a list that gets modified each time by put or delete. Though I just don't quite have my head around managing states between connections of different type. The rest example for the most part is stateless due to their not being an API token associated with request. 

There is likely other methods through default request headers but I felt the need to not over complicate things here.

I was concerned about not having redirects though I realized the API should be accessible by a HTTP client. The `curl` with the response being returned to the application.

Any tips or advice on how to improve this & make it more compatible would be more than welcome.